### PR TITLE
Rename to use underscores

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.4.9" %}
 package:
-  name: sphinx-bootstrap-theme
+  name: sphinx_bootstrap_theme
   version: {{ version }}
 
 source:


### PR DESCRIPTION
The sphinx bootstrap theme package in pypi uses underscores and their
docs recommend using underscores.  It was my mistake to use hyphens here
on conda-forge

Closes #2

@jakirkham I'm assuming we should remove the hyphenated packages on
anaconda.org/conda-forge?