### PR TITLE
Rename to use underscores

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+* text=auto
+
+meta.yaml text eol=lf
+build.sh text eol=lf
+bld.bat text eol=crlf

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
     - CONDA_PY=27
     - CONDA_PY=34
     - CONDA_PY=35
+    - CONDA_PY=36
   global:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     - secure: "bKdYEvb9dcGY8ueiN31gslLwYuzLIYyoLYGO0mpv1UZQyjB3mMKdQBqSeccw+2YYjtvL0Hic0+FiDqYehtOuUftc+lAx1PpBTeLPLSxjdxtFwc4El8riZMt50iUNMGYXau3+FjevONEt5K1S8LyG1y/k+ENmo/shkdRHnfTKoQxMKwP5Nvt/6o6QAqEUBYeVXaQK+cSrMeJOCkX81cqEmpNeJX6/WsFRhq7nqTxpacacqJ35u+/wJSgcEyRbFgEiy5O4YgZiuu6nBifAJbRz1w56pRi8o1yw0ti8N67+MLwRH0kVrq3ZmJMFR0LQlI2/mMWmHi1F81XbkmLyyeh7Oyeh9QcF+gONtyoc3QzKp3ht5cN2WaFO8hbFS/qc9ArtD8xhcauexDOQL0nCZouOvWJT8+fGyaFsSEglmtAlFcMdSKWIcvMdqdine1JgSvHrajQ4FoqXZlLvJtyKRxfd63yXc/E8DP5wA5Tq7jDTUaNSzhwCQrRIKibUcoRjSMLmzc92mRLoQ47m9R+Gh3RhPq3YKzqo9wtQSH7ykz4Ln8iRRAn3gqvEX4lDCC9d/AIeqS0e6FVIUsDBzVzmTPdK+sxLjFotZEy+THh4FTmXvpqmSHYScTllYVRLoU2KleDMz5lHNJ2L9Eo7IuRSGoA3y41FDyi7tfD+Abask6TlFJA="
@@ -25,9 +26,9 @@ before_install:
 
 install:
     - |
-      MINICONDA_URL="http://repo.continuum.io/miniconda"
+      MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       source /Users/travis/miniconda3/bin/activate root

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-About sphinx-bootstrap-theme
+About sphinx_bootstrap_theme
 ============================
 
 Home: http://ryan-roemer.github.com/sphinx-bootstrap-theme/README.html
@@ -11,27 +11,38 @@ Summary: Sphinx Bootstrap Theme.
 
 
 
-Installing sphinx-bootstrap-theme
+Current build status
+====================
+
+Linux: [![Circle CI](https://circleci.com/gh/conda-forge/sphinx-bootstrap-theme-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/sphinx-bootstrap-theme-feedstock)
+OSX: [![TravisCI](https://travis-ci.org/conda-forge/sphinx-bootstrap-theme-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/sphinx-bootstrap-theme-feedstock)
+Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/sphinx-bootstrap-theme-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/sphinx-bootstrap-theme-feedstock/branch/master)
+
+Current release info
+====================
+Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/sphinx_bootstrap_theme/badges/version.svg)](https://anaconda.org/conda-forge/sphinx_bootstrap_theme)
+Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/sphinx_bootstrap_theme/badges/downloads.svg)](https://anaconda.org/conda-forge/sphinx_bootstrap_theme)
+
+Installing sphinx_bootstrap_theme
 =================================
 
-Installing `sphinx-bootstrap-theme` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
+Installing `sphinx_bootstrap_theme` from the `conda-forge` channel can be achieved by adding `conda-forge` to your channels with:
 
 ```
 conda config --add channels conda-forge
 ```
 
-Once the `conda-forge` channel has been enabled, `sphinx-bootstrap-theme` can be installed with:
+Once the `conda-forge` channel has been enabled, `sphinx_bootstrap_theme` can be installed with:
 
 ```
-conda install sphinx-bootstrap-theme
+conda install sphinx_bootstrap_theme
 ```
 
-It is possible to list all of the versions of `sphinx-bootstrap-theme` available on your platform with:
+It is possible to list all of the versions of `sphinx_bootstrap_theme` available on your platform with:
 
 ```
-conda search sphinx-bootstrap-theme --channel conda-forge
+conda search sphinx_bootstrap_theme --channel conda-forge
 ```
-
 
 
 About conda-forge
@@ -68,30 +79,18 @@ Terminology
 **conda-forge** - the place where the feedstock and smithy live and work to
                   produce the finished article (built conda distributions)
 
-Current build status
-====================
 
-Linux: [![Circle CI](https://circleci.com/gh/conda-forge/sphinx-bootstrap-theme-feedstock.svg?style=shield)](https://circleci.com/gh/conda-forge/sphinx-bootstrap-theme-feedstock)
-OSX: [![TravisCI](https://travis-ci.org/conda-forge/sphinx-bootstrap-theme-feedstock.svg?branch=master)](https://travis-ci.org/conda-forge/sphinx-bootstrap-theme-feedstock)
-Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/conda-forge/sphinx-bootstrap-theme-feedstock?svg=True)](https://ci.appveyor.com/project/conda-forge/sphinx-bootstrap-theme-feedstock/branch/master)
-
-Current release info
-====================
-Version: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/sphinx-bootstrap-theme/badges/version.svg)](https://anaconda.org/conda-forge/sphinx-bootstrap-theme)
-Downloads: [![Anaconda-Server Badge](https://anaconda.org/conda-forge/sphinx-bootstrap-theme/badges/downloads.svg)](https://anaconda.org/conda-forge/sphinx-bootstrap-theme)
-
-
-Updating sphinx-bootstrap-theme-feedstock
+Updating sphinx_bootstrap_theme-feedstock
 =========================================
 
-If you would like to improve the sphinx-bootstrap-theme recipe or build a new
+If you would like to improve the sphinx_bootstrap_theme recipe or build a new
 package version, please fork this repository and submit a PR. Upon submission,
 your changes will be run on the appropriate platforms to give the reviewer an
 opportunity to confirm that the changes result in a successful build. Once
 merged, the recipe will be re-built and uploaded automatically to the
 `conda-forge` channel, whereupon the built conda packages will be available for
 everybody to install and use from the `conda-forge` channel.
-Note that all branches in the conda-forge/sphinx-bootstrap-theme-feedstock are
+Note that all branches in the conda-forge/sphinx_bootstrap_theme-feedstock are
 immediately built and any created packages are uploaded, so PRs should be based
 on branches in forks and branches in the main repository should only be used to
 build distinct package versions.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,16 +4,11 @@
 
 environment:
 
-  CONDA_INSTALL_LOCN: "C:\\conda"
-
   # SDK v7.0 MSVC Express 2008's SetEnv.cmd script will fail if the
   # /E:ON and /V:ON options are not enabled in the batch script intepreter
   # See: http://stackoverflow.com/a/13751649/163740
   CMD_IN_ENV: "cmd /E:ON /V:ON /C obvci_appveyor_python_build_env.cmd"
 
-  # We set a default Python version for the miniconda that is to be installed. This can be
-  # overridden in the matrix definition where appropriate.
-  CONDA_PY: "27"
   BINSTAR_TOKEN:
     # The BINSTAR_TOKEN secure variable. This is defined canonically in conda-forge.yml.
     secure: MP4hZYylDyUWEsrt3u3cod2sbFeRwUziH02mvQOdbjsTO/l1yIxDkP/76rSIjcGC
@@ -21,21 +16,35 @@ environment:
   matrix:
     - TARGET_ARCH: x86
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda
 
     - TARGET_ARCH: x64
       CONDA_PY: 27
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3
 
     - TARGET_ARCH: x64
       CONDA_PY: 34
+      CONDA_INSTALL_LOCN: C:\\Miniconda3-x64
 
     - TARGET_ARCH: x86
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35
 
     - TARGET_ARCH: x64
       CONDA_PY: 35
+      CONDA_INSTALL_LOCN: C:\\Miniconda35-x64
+
+    - TARGET_ARCH: x86
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda
+
+    - TARGET_ARCH: x64
+      CONDA_PY: 36
+      CONDA_INSTALL_LOCN: C:\\Miniconda-x64
 
 
 # We always use a 64-bit machine, but can build x86 distributions
@@ -56,24 +65,25 @@ install:
 
     # Cywing's git breaks conda-build. (See https://github.com/conda-forge/conda-smithy-feedstock/pull/2.)
     - cmd: rmdir C:\cygwin /s /q
-    - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
-    - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add our channels.
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda config --set show_channel_urls true
+    - cmd: conda config --add channels conda-forge
 
     # Add a hack to switch to `conda` version `4.1.12` before activating.
     # This is required to handle a long path activation issue.
     # Please see PR ( https://github.com/conda/conda/pull/3349 ).
-    - cmd: set "OLDPATH=%PATH%"
-    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
     - cmd: conda install --yes --quiet conda=4.1.12
     - cmd: set "PATH=%OLDPATH%"
     - cmd: set "OLDPATH="
 
+    # Actually activate `conda`.
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 
-    - cmd: conda config --set show_channel_urls true
-    - cmd: conda install -c pelson/channel/development --yes --quiet obvious-ci
-    - cmd: conda config --add channels conda-forge
+    - cmd: conda install -n root --quiet --yes obvious-ci
     - cmd: conda install -n root --quiet --yes conda-forge-build-setup
     - cmd: run_conda_forge_build_setup
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -41,7 +41,7 @@ conda clean --lock
 conda install --yes --quiet conda-forge-build-setup
 source run_conda_forge_build_setup
 
-# Embarking on 3 case(s).
+# Embarking on 4 case(s).
     set -x
     export CONDA_PY=27
     set +x
@@ -56,6 +56,12 @@ source run_conda_forge_build_setup
 
     set -x
     export CONDA_PY=35
+    set +x
+    conda build /recipe_root --quiet || exit 1
+    upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1
+
+    set -x
+    export CONDA_PY=36
     set +x
     conda build /recipe_root --quiet || exit 1
     upload_or_check_non_existence /recipe_root conda-forge --channel=main || exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set version = "0.4.9" %}
 package:
-  name: sphinx-bootstrap-theme
+  name: sphinx_bootstrap_theme
   version: {{ version }}
 
 source:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -26,9 +26,18 @@ test:
     - sphinx_bootstrap_theme
 
 about:
-  home: http://ryan-roemer.github.com/sphinx-bootstrap-theme/README.html
-  license: MIT License
+  home: http://ryan-roemer.github.com/sphinx-bootstrap-theme/
+  license: MIT
+  license_family: MIT
+  license_file: LICENSE.txt
   summary: 'Sphinx Bootstrap Theme.'
+  description: |
+      This Sphinx theme integrates the Bootstrap CSS / JavaScript framework
+      with various layout options, hierarchical menu navigation, and
+      mobile-friendly responsive design. It is configurable, extensible, and
+      can use any number of different Bootswatch CSS themes.
+  doc_url: http://ryan-roemer.github.io/sphinx-bootstrap-theme/
+  dev_url: http://ryan-roemer.github.com/sphinx-bootstrap-theme/
 
 extra:
   recipe-maintainers:


### PR DESCRIPTION
The sphinx bootstrap theme package in pypi uses underscores and their
docs recommend using underscores. It was my mistake to use hyphens here
on conda-forge

Closes #2

@jakirkham I'm assuming we should remove the hyphenated packages on
anaconda.org/conda-forge?